### PR TITLE
ci: автоматична синхронізація upstream та публікація Docker образу

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,182 @@
+name: Sync upstream and release UA version
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force release even if tag already exists'
+        type: boolean
+        default: false
+
+jobs:
+  sync-and-release:
+    name: Merge upstream, build & push Docker
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+
+    steps:
+      - name: Checkout main-UA-version
+        uses: actions/checkout@v4
+        with:
+          ref: main-UA-version
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # sct-tools/overseerr is the upstream Overseerr repo (referenced as sct:develop in merge history)
+      - name: Get latest upstream release tag
+        id: upstream
+        run: |
+          TAG=$(curl -sf \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/sct-tools/overseerr/releases/latest" \
+            | jq -r '.tag_name')
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "::error::Could not fetch upstream release tag"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ua_tag=${TAG}-ua" >> "$GITHUB_OUTPUT"
+          echo "Upstream latest: $TAG"
+
+      - name: Check if fork already has this release
+        id: check
+        run: |
+          UA_TAG="${{ steps.upstream.outputs.ua_tag }}"
+          if git ls-remote --tags origin "refs/tags/$UA_TAG" | grep -q . \
+              && [ "${{ inputs.force }}" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$UA_TAG already released — nothing to do"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add upstream remote and fetch tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git remote add upstream https://github.com/sct-tools/overseerr.git
+          git fetch upstream "refs/tags/${{ steps.upstream.outputs.tag }}:refs/tags/_upstream-fetch"
+
+      - name: Merge upstream tag into main-UA-version
+        if: steps.check.outputs.skip != 'true'
+        id: merge
+        run: |
+          if git merge _upstream-fetch \
+              --no-edit \
+              -m "chore: merge upstream ${{ steps.upstream.outputs.tag }}"; then
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          else
+            git merge --abort || true
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+          fi
+          git tag -d _upstream-fetch || true
+
+      - name: Open issue on merge conflict
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.upstream.outputs.tag }}';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 Merge conflict with upstream ${tag}`,
+              body: [
+                `Automatic merge of \`${tag}\` into \`main-UA-version\` failed due to conflicts.`,
+                '',
+                '**Action needed:** resolve conflicts manually and push to `main-UA-version`.',
+                '',
+                `Upstream release: https://github.com/sct-tools/overseerr/releases/tag/${tag}`,
+              ].join('\n'),
+            });
+            core.setFailed(`Merge conflict with upstream ${tag} — issue created`);
+
+      # After every merge, ensure the fork-specific display name for Russian stays.
+      # The upstream may change it back to plain 'русский'.
+      - name: Restore fork-specific patches
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        run: |
+          node -e "
+            const fs = require('fs');
+            const file = 'src/context/LanguageContext.tsx';
+            let src = fs.readFileSync(file, 'utf8');
+            src = src.replace(/display: '[Рр]усский'(?!\s*💩)/, \"display: 'pусский 💩'\");
+            fs.writeFileSync(file, src);
+          "
+          if ! git diff --quiet; then
+            git commit -am "fix: restore fork patches after upstream merge"
+          fi
+
+      - name: Tag release and push
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        run: |
+          UA_TAG="${{ steps.upstream.outputs.ua_tag }}"
+          git tag "$UA_TAG"
+          git push origin main-UA-version
+          git push origin "$UA_TAG"
+
+      - name: Set up QEMU
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/mrkaktuz/overseerr:latest
+            ghcr.io/mrkaktuz/overseerr:${{ steps.upstream.outputs.ua_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub release
+        if: steps.check.outputs.skip != 'true' && steps.merge.outputs.failed != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const upTag = '${{ steps.upstream.outputs.tag }}';
+            const uaTag = '${{ steps.upstream.outputs.ua_tag }}';
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: uaTag,
+              name: uaTag,
+              target_commitish: 'main-UA-version',
+              body: [
+                `Based on upstream [${upTag}](https://github.com/sct-tools/overseerr/releases/tag/${upTag}).`,
+                '',
+                '### UA additions',
+                '- 🇺🇦 Перевірка наявності UA аудіо/субтитрів через [Kinobaza](https://kinobaza.com.ua)',
+                '- 🇺🇦 Українська локалізація',
+                '',
+                '**Docker image:**',
+                '```',
+                `docker pull ghcr.io/mrkaktuz/overseerr:${uaTag}`,
+                '```',
+              ].join('\n'),
+              draft: false,
+              prerelease: false,
+            });

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -31,13 +31,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      # sct-tools/overseerr is the upstream Overseerr repo (referenced as sct:develop in merge history)
+      # sct/overseerr is the upstream Overseerr repo (referenced as sct:develop in merge history)
       - name: Get latest upstream release tag
         id: upstream
         run: |
           TAG=$(curl -sf \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/sct-tools/overseerr/releases/latest" \
+            "https://api.github.com/repos/sct/overseerr/releases/latest" \
             | jq -r '.tag_name')
           if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
             echo "::error::Could not fetch upstream release tag"
@@ -62,7 +62,7 @@ jobs:
       - name: Add upstream remote and fetch tag
         if: steps.check.outputs.skip != 'true'
         run: |
-          git remote add upstream https://github.com/sct-tools/overseerr.git
+          git remote add upstream https://github.com/sct/overseerr.git
           git fetch upstream "refs/tags/${{ steps.upstream.outputs.tag }}:refs/tags/_upstream-fetch"
 
       - name: Merge upstream tag into main-UA-version
@@ -94,7 +94,7 @@ jobs:
                 '',
                 '**Action needed:** resolve conflicts manually and push to `main-UA-version`.',
                 '',
-                `Upstream release: https://github.com/sct-tools/overseerr/releases/tag/${tag}`,
+                `Upstream release: https://github.com/sct/overseerr/releases/tag/${tag}`,
               ].join('\n'),
             });
             core.setFailed(`Merge conflict with upstream ${tag} — issue created`);
@@ -166,7 +166,7 @@ jobs:
               name: uaTag,
               target_commitish: 'main-UA-version',
               body: [
-                `Based on upstream [${upTag}](https://github.com/sct-tools/overseerr/releases/tag/${upTag}).`,
+                `Based on upstream [${upTag}](https://github.com/sct/overseerr/releases/tag/${upTag}).`,
                 '',
                 '### UA additions',
                 '- 🇺🇦 Перевірка наявності UA аудіо/субтитрів через [Kinobaza](https://kinobaza.com.ua)',


### PR DESCRIPTION
## Що додано

Новий workflow `.github/workflows/sync-upstream.yml` який автоматизує весь цикл оновлень.

## Як працює

1. **Тригер**: щодня о 06:00 UTC + ручний запуск (`workflow_dispatch`)
2. Перевіряє останній release у `sct/overseerr`
3. Якщо вже є тег `{версія}-ua` у форку — пропускає
4. Робить `git merge` тегу upstream в `main-UA-version`
5. Відновлює патч: `display: 'pусский 💩'` якщо upstream перезаписав
6. Якщо конфлікт — відкриває GitHub Issue замість тихого падіння
7. Збирає Docker образ для `linux/amd64` + `linux/arm64`
8. Пушить `ghcr.io/mrkaktuz/overseerr:latest` та `ghcr.io/mrkaktuz/overseerr:{версія}-ua`
9. Створює GitHub Release з описом

## Після злиття

Потрібно переконатись що `main-UA-version` є **default branch** репо (Settings → General → Default branch) — інакше scheduled cron не запуститься.